### PR TITLE
ReverseClassicalMechanics: add illustration of parallelepipeds

### DIFF
--- a/reverse-classical-mechanics.tex
+++ b/reverse-classical-mechanics.tex
@@ -1190,6 +1190,32 @@ This pattern is straightforward and more easily generalized. We call these funct
 
 Since $k$-forms act over infinitesimal regions, they will have some key properties.  First, note that each infinitesimal region can be understood as a parallelepiped, and a parallelepiped is fully identified by its sides. Therefore, a $k$-form can be understood as acting on a set of infinitesimal displacements, the sides of the parallelepiped, whose number matches the dimensionality of the form. A one-form will take one displacement, a two-form two displacements and so on. Second, as they are linear functions of the infinitesimal regions, they will also be linear functions of the vectors that define these infinitesimal regions. Lastly, all forms must be anti-symmetric because switching the order of the sides does not change the parallelepiped, but it changes its orientation.
 
+\begin{figure}
+	\centering
+	\begin{tikzpicture}
+		\draw[->] (0, 0) -- (1, 1);
+	\end{tikzpicture}
+	\hspace{1cm}
+	\begin{tikzpicture}
+		\draw[->] (0, 0) -- (1, 0);
+		\draw[->] (0, 0) -- (0, 1);
+		\draw[dashed] (0, 1) -- (1, 1) -- (1, 0);
+	\end{tikzpicture}
+	\hspace{1cm}
+	\begin{tikzpicture}
+		\draw[->] (0, 0) -- (1, 0);
+		\draw[->] (0, 0) -- (0, 1);
+		\draw[->] (0, 0) -- (0.4, 0.4);
+		\draw[dashed] (1, 0) -- (1, 1) -- (0, 1);
+		\draw[dashed] (1, 0) -- (1.4, 0.4) -- (0.4, 0.4);
+		\draw[dashed] (0, 1) -- (0.4, 1.4) -- (0.4, 0.4);
+		\draw[dashed] (1, 1) -- (1.4, 1.4);
+		\draw[dashed] (1.4, 0.4) -- (1.4, 1.4);
+		\draw[dashed] (0.4, 1.4) -- (1.4, 1.4);
+	\end{tikzpicture}
+	\caption{Examples of vectors defining parallelepipeds in one, two, and three dimensions.}
+\end{figure}
+
 We can write displacements and forms in terms of components and basis elements
 \begin{equation}
 	\begin{aligned}


### PR DESCRIPTION
During today's reading group, I thought it might be helpful to add a figure that illustrates how vectors define parallelepipeds in one, two, and three dimensions.

<img width="979" height="157" alt="image" src="https://github.com/user-attachments/assets/82b9f534-1d7c-4de5-94c3-4e5fc96f1f53" />
